### PR TITLE
Don't call `LocaleChanged` when same value has been set

### DIFF
--- a/Editor/CustomLocalization4EditorExtension.Editor.cs
+++ b/Editor/CustomLocalization4EditorExtension.Editor.cs
@@ -354,7 +354,10 @@ namespace CustomLocalization4EditorExtension
                 if (!ParsedByIsoCode.TryGetValue(localeCode, out var locale)) return false;
 
                 EditorPrefs.SetString(_localeSettingEditorPrefsKey, localeCode);
-
+                if(CurrentLocale == locale)
+                {
+                    return true;
+                }
                 CurrentLocale = locale;
 
                 LocaleChanged?.Invoke();


### PR DESCRIPTION
`LocaleAssetConfig.TrySetLocale` calls `LocaleChanged` even if same value has been set.

This is inconsistent between behavior of `LocaleAssetConfig.DrawLanguagePicker`, and also causes infinite loop.